### PR TITLE
Error check for undefined access token

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class NestCamPlatform {
     {
       throw new Error('access_token is not defined in the Homebridge config');
     }
-    self.nestAPI = new Nest(self.config['access_token']);
+     self.nestAPI = new Nest(accessToken);
     self.nestAPI.on('cameras', (cameras) => {
       let configuredAccessories = [];
       cameras.forEach((camera) => {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class NestCamPlatform {
 
   didFinishLaunching() {
     let self = this;
-    let access_token = self.config['access_token'];
+    let accessToken = self.config['access_token'];
     if ( typeof access_token == 'undefined' || access_token )
     {
       throw new Error('access_token is not defined in the Homebridge config');

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class NestCamPlatform {
   didFinishLaunching() {
     let self = this;
     let accessToken = self.config['access_token'];
-    if ( typeof access_token == 'undefined' || access_token )
+    if ( typeof accessToken == 'undefined' || accessToken )
     {
       throw new Error('access_token is not defined in the Homebridge config');
     }

--- a/index.js
+++ b/index.js
@@ -32,6 +32,11 @@ class NestCamPlatform {
 
   didFinishLaunching() {
     let self = this;
+    let access_token = self.config['access_token'];
+    if ( typeof access_token == 'undefined' || access_token )
+    {
+      throw new Error('access_token is not defined in the Homebridge config');
+    }
     self.nestAPI = new Nest(self.config['access_token']);
     self.nestAPI.on('cameras', (cameras) => {
       let configuredAccessories = [];


### PR DESCRIPTION
After a lot of troubleshooting, I realized I'd made a very dumb easy typo when I updated my config for .12. Adding this as a way to catch this condition so you don't just mysteriously fail with 403, etc. 

Note, I'm not a JS expert, but this seemed to work; may not be idomatic. Figured I'd try to do the PR vs just complaining in an issue. 😄