### PR TITLE
Add accessory information and 4:3 resolutions for Nest Hello

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
 'use strict';
 
-let Accessory, hap, UUIDGen;
+let Accessory, Service, Characteristic, hap, UUIDGen;
 const Nest = require('./lib/nest').NestAPI;
+const modelTypes = {
+  10: 'Nest Cam IQ Indoor',
+  12: 'Nest Hello'
+}
 
 module.exports = (homebridge) => {
   Accessory = homebridge.platformAccessory;
+  Service = homebridge.hap.Service;
+  Characteristic = homebridge.hap.Characteristic;
   hap = homebridge.hap;
   UUIDGen = homebridge.hap.uuid;
 
@@ -43,8 +49,14 @@ class NestCamPlatform {
       cameras.forEach((camera) => {
         camera.configureWithHAP(hap, self.config);
         let name = camera.name;
+        let model = (modelTypes.hasOwnProperty(camera.type)) ? modelTypes[camera.type] : 'Unknown';
         let uuid = UUIDGen.generate(camera.uuid);
         let accessory = new Accessory(name, uuid, hap.Accessory.Categories.CAMERA);
+        let accessoryInformation = accessory.getService(Service.AccessoryInformation);
+        accessoryInformation.setCharacteristic(Characteristic.Manufacturer, 'Nest');
+        accessoryInformation.setCharacteristic(Characteristic.Model, model);
+        accessoryInformation.setCharacteristic(Characteristic.SerialNumber, camera.serialNumber);
+        accessoryInformation.setCharacteristic(Characteristic.FirmwareRevision, camera.softwareVersion);
         self.log('Create camera - ' + name);
         accessory.configureCameraSource(camera);
         configuredAccessories.push(accessory);

--- a/lib/nestcam.js
+++ b/lib/nestcam.js
@@ -16,6 +16,8 @@ class NestCam {
     self.name = info.name;
     self.uuid = info.uuid;
     self.serialNumber = info.serial_number;
+    self.softwareVersion = info.combined_software_version;
+    self.type = info.type;
     self.nexusTalkHost = info.direct_nexustalk_host;
     self.apiHost = info.nexus_api_http_server.slice(8); // remove https://
   }
@@ -41,15 +43,26 @@ class NestCam {
     self.sessions = {};
 
     let numberOfStreams = 2;
-    let videoResolutions = [
-      [320, 180, 30],
-      [320, 180, 15],
-      [320, 240, 15],
-      [480, 270, 30],
-      [480, 360, 30],
-      [640, 360, 30],
-      [1280, 720, 30]
-    ];
+    let videoResolutions;
+    // Use 4:3 aspect ratio resolutions for Nest Hello cameras
+    if (self.type == 12) {
+      videoResolutions = [
+        [320, 240, 30],
+        [480, 360, 30],
+        [640, 480, 30],
+        [1280, 960, 30],
+        [1600, 1200, 30]
+      ];
+    // Use 16:9 aspect ratio resolutions for all other Nest Cameras
+    } else {
+      videoResolutions = [
+        [320, 180, 30],
+        [480, 270, 30],
+        [640, 360, 30],
+        [1280, 720, 30],
+        [1920, 1080, 30]
+      ];
+    }
 
     let options = {
       proxy: false,
@@ -143,8 +156,9 @@ class NestCam {
   }
 
   createCameraControlService() {
+    let self = this;
     let controlService = new Service.CameraControl();
-    this.services.push(controlService);
+    self.services.push(controlService);
   }
 
   _createStreamControllers(maxStreams, options) {


### PR DESCRIPTION
1. Add accessory information support.
2. Add variable resolutions depending on camera type (4:3 for Nest Hello and 16:9 for everything else), fixes #38.

I'm not an expert on all of the exact resolutions required. This setup works fine for me, but any feedback is appreciated.